### PR TITLE
fix: let parse still work even if the url in question matches the cur…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,6 @@ export class Router {
     this.routes.push(value);
   }
   constructor(routes: Record<string, string>) {
-    this.prev = '';
     Object.keys(routes).map(name => {
       let value = routes[name]
       value = value.replace(/\/$/g, '') || '/'
@@ -54,8 +53,6 @@ export class Router {
     let rawPath = _path.replace(/\/$/, '') || '/'
     const [path, qParams = ''] = rawPath.split('?');
     const qp = this.getQueryParams(qParams);
-    if (this.prev === rawPath) return false
-    this.prev = rawPath
 
     for (let [route, pattern, cb] of this.routes) {
       let match = path.match(pattern)


### PR DESCRIPTION
…rent mounted

I'm using `parse` to go from url to route and params and then modifying them. If I mount to `/users/1` and then `parse('/users/1')` I get a false. Seems like the prev should be handled in `open()` internally? Just opening this to get the conversation started.